### PR TITLE
Fix _uvcache object initialization. Closes GH-5

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports.Rect = Rect;
 // pack image/rect to the atlas
 Atlas.prototype.pack = function(rect) {
   this._cache = [];
-  this._uvcache = [];
+  this._uvcache = Object.create(null);
   rect = this._toRect(rect);
 
   if (this.img && this.tilepad) {
@@ -136,9 +136,6 @@ Atlas.prototype.index = function() {
 
 Atlas.prototype.uv = function(w, h) {
   var self = this;
-  if (self._uvcache.length > 0) {
-    return self._uvcache;
-  }
   w = w || self.rect.w;
   h = h || self.rect.h;
   var isPad = this.tilepad;


### PR DESCRIPTION
Changes the _uvcache initialization from [] to Object.create(null) (note: not using {} so that inherited Object properties e.g. toString are [not added](http://stackoverflow.com/questions/15518328/creating-js-object-with-object-createnull)). Fixes use of this variable as an array, which showed up as empty in the Chrome debugger.

Also removed the `.length > 0` cache check, which had no effect. This could be replaced with `Object.keys(this._uvcache).length > 0` but then cache invalidation is needed (I originally made this change, but in my code `uv()` may be called before all textures are loaded, returning a stale UV cache causing texture rendering issues. Returning the cache & invalidating it as needed could be added later, separately). 

Fixes GH-5
