### PR TITLE
Allow canvas elements to be packed too

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ Atlas.prototype._ontoCanvas = function(node) {
 // make sure we're always working with rects
 Atlas.prototype._toRect = function(rect) {
   // if rect is an image
-  if (rect.nodeName && rect.nodeName === 'IMG') {
+  if (rect.nodeName && (rect.nodeName === 'IMG' || rect.nodeName === 'CANVAS')) {
     this.img = rect;
     rect = new Rect(rect.x, rect.y, rect.width, rect.height);
   }


### PR DESCRIPTION
Minor change that allows `<canvas>` elements to be packed too. Useful when you want to resize the images before packing them in the atlas.